### PR TITLE
Updated library version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/healthcheck",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/healthcheck",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "healthcheck library for modules",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
It was published in NPM an invalid package for the last version.
So, it was necessary to bump the version to publish a valid one.